### PR TITLE
Redraw during resize fix

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -2,6 +2,7 @@ html, body {
   padding-top: 10px;
   padding-bottom: 30px;
   margin: 0;
+  min-width: 1024px;
   width: 100%;
   height:100%;
 }

--- a/css/vispnet.css
+++ b/css/vispnet.css
@@ -23,7 +23,9 @@
 }
 #forcenet {
   margin-top: 10px;
-  height: 500px;
+  margin-right: auto;
+  margin-left: auto;
+  min-height: 500px;
 }
 
 /* d3.parcoord */
@@ -33,6 +35,9 @@
 }
 #linnetpcp {
   display: none;
+  min-width: 1024px;
+  margin-right: auto;
+  margin-left: auto;
 }
 
 #pcp-hint {

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
               <a tabindex="0" class="glyphicon glyphicon-info-sign input-info-sign" role="button" data-toggle="popover" data-trigger="focus" data-html="true" data-content="Type the URL (http://... or https://...) of a network CSV created using an <a href='help.html#csv-format-help'>extended edge-list format.</a> Then click on <span class='label label-default'>Fetch</span> button on the right." aria-hidden="true"></a>
               <!-- url input -->
               <div class="input-group">
-                <input id="csv-file-url" type="text" class="form-control" placeholder="location of CSV" autocomplete="off" autofocus>
+                <input id="csv-file-url" type="text" class="form-control" placeholder="location of CSV" autocomplete="off">
                 
                 <span class="input-group-btn">
                   <button id="csv-process-btn" class="btn btn-default" type="button" data-loading-text="Loading..." autocomplete="off">Fetch</button>
@@ -96,7 +96,7 @@
             <a tabindex="0" class="glyphicon glyphicon-info-sign input-info-sign" role="button" data-toggle="popover" data-trigger="focus" data-html="true" data-content="These buttons will load a <a href='help.html#sample-networks-help'>sample network CSVs</a> in VisPNet." aria-hidden="true"></a>
             
             <span class="input-group-btn">
-              <button id="sample-network1" class="btn btn-default samplebtn" type="button" autocomplete="off">SimPPI Sample</button>
+              <button id="sample-network1" class="btn btn-default samplebtn" type="button" autocomplete="off" autofocus>SimPPI Sample</button>
             </span>
             <!-- span class="input-group-btn">
               <button id="sample-network3" class="btn btn-default samplebtn" type="button" autocomplete="off" disabled>Yeast Gene Co-expression</button>

--- a/js/d3.parcoords.js
+++ b/js/d3.parcoords.js
@@ -230,6 +230,7 @@ d3.parcoords = function(config) {
             if (__.types[p] == "string" && (uniques > 60 || uniques < 2)) {
                 return false;
             }
+            console.log("Found axis with " + uniques + " unique ordinal values. That's too crowded for an axis, therefore, not showing that axis here.");
             return true;
         })); // DIVYA's mod: MISSING AXES are probably due to this
 

--- a/js/pcp-supporters.js
+++ b/js/pcp-supporters.js
@@ -102,13 +102,13 @@ $("#downloadGlyph").on("click", function () {
 /* if the window is resized, we redraw the plot.
    Unfortunately, the plot won't remember brush position for now.
 */
-$(window).resize(function(){
-	if(pc_progressive) {
-		pc_progressive.width($("#linnetpcp").width()).height($("#linnetpcp").height());
-		pc_progressive.updateAxes();
-  }
+// $(window).resize(function(){
+// 	if(pc_progressive) {
+// 		pc_progressive.width($("#linnetpcp").width()).height($("#linnetpcp").height());
+// 		pc_progressive.updateAxes();
+//   }
 	
-});
+// });
 
 /* If HTML5 File API is available, let user 
    pick local files */


### PR DESCRIPTION
- Removing the redraw of the plot during window resize event. 
- Providing minimum sizes for pcp and forcenet to allow cleaner view
- Adding a console message when an axis is removed from pcp due to too many ordinal values
- Move auto-focus to the sample network button to make that the first grab